### PR TITLE
Add a page to describe VNCTF

### DIFF
--- a/config/navbar.yml
+++ b/config/navbar.yml
@@ -15,6 +15,9 @@ content:
   - id: join
     text: Join Us
     link: /join
+  - id: vnctf
+    text: VNCTF
+    link: /vnctf
 icon:
   - icon: ":github:"
     link: https://github.com/vn-sec/vn-website

--- a/config/vnctf.md
+++ b/config/vnctf.md
@@ -1,0 +1,10 @@
+# VNCTF Event
+
+## Event Details
+
+- **Date:** 2025年2月8日 10:00 - 2025年2月9日 10:00
+- **Participants:** Nearly 1000 participants
+
+## Description
+
+The event is organized by the V&N team, focusing on moderate difficulty and progressive challenges. The questions are based on interesting and fun knowledge points learned by the team members, aiming to let everyone learn and enjoy the process of solving problems.

--- a/site-config.yml
+++ b/site-config.yml
@@ -7,6 +7,7 @@ page:
   achievements: ./config/achievements.md
   members: ./config/members.yml
   join: ./config/join.md
+  vnctf: ./config/vnctf.md
 
 footer:
   - Copyright (c) [V&N Team](:link-normal:!https://vnteam.cn)

--- a/src/pages/vnctf.astro
+++ b/src/pages/vnctf.astro
@@ -1,0 +1,20 @@
+---
+import LayoutPage from "@/layouts/LayoutPage.astro";
+import Page from "@/components/Page.astro";
+import { parsedSiteConfig } from "@/site-config";
+
+const conf = await parsedSiteConfig.page.vnctf;
+const doc_title = [conf.title, await parsedSiteConfig.title].filter(Boolean).join(" | ");
+---
+
+<LayoutPage title={doc_title} autoHideNav={true} useBg={true} active="vnctf" padTopNav={true}>
+    <Page
+        title={conf.title}
+        subtitle={conf.subtitle}
+        anchor={true}
+        content={conf.content}
+        mdOptions={{ externalLink: true }}
+    />
+</LayoutPage>
+
+<style lang="scss"></style>

--- a/src/site-config/parser.ts
+++ b/src/site-config/parser.ts
@@ -73,6 +73,27 @@ export const SiteConfigParser = {
                     }
                 }
             )
+        },
+
+        "vnctf": async (sc: SiteConfig) => {
+            let conf = sc.page.vnctf ?? { content: "" }
+            return await autoGetConfig(
+                conf,
+                async (f, _, { Markdown },) => {
+                    const data = Markdown.parse(f);
+                    if (Markdown.isYamlRecord(data.frontmatter)) {
+                        return {
+                            title: data.frontmatter["title"] ? data.frontmatter["title"].toString() : undefined,
+                            subtitle: data.frontmatter["subtitle"] ? data.frontmatter["subtitle"].toString() : undefined,
+                            content: data.content
+                        };
+                    } else {
+                        return {
+                            content: data.content
+                        };
+                    }
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
Add a new page to describe the VNCTF event.

* Add a new entry to `config/navbar.yml` to include a link to `/vnctf`.
* Add a new entry to `site-config.yml` to reference the `vnctf` page.
* Create a new markdown file `config/vnctf.md` with the VNCTF event description, date, time, and participation details.
* Add a new file `src/pages/vnctf.astro` to create the `/vnctf` page, importing necessary components and rendering the VNCTF event details.
* Modify `src/site-config/parser.ts` to add a new entry to the `page` object with `vnctf` configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ZianTT/vnteam-website/pull/1?shareId=380d76ee-e69e-4ee2-9c3a-332ab9bec96f).